### PR TITLE
Enable Travis builds and fix lint errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: go
+
+go:
+    - 1.7
+    - 1.8
+    - tip
+
+go_import_path: github.com/intel/tfortools
+
+matrix:
+  allow_failures:
+  - go: tip
+
+before_install:
+  - go get github.com/alecthomas/gometalinter
+  - gometalinter --install
+
+script:
+   - go env
+   - go test -v ./...
+   - gometalinter --tests --vendor --disable-all --enable=misspell --enable=vet --enable=ineffassign --enable=gofmt --enable=gocyclo --cyclo-over=15 --enable=golint --enable=errcheck --enable=deadcode ./...

--- a/example_test.go
+++ b/example_test.go
@@ -376,17 +376,20 @@ func ExampleOptDescribe() {
 func ExampleConfig_AddCustomFn() {
 	nums := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
 	cfg := NewConfig(OptAllFns)
-	cfg.AddCustomFn(func(n []int) int {
+	err := cfg.AddCustomFn(func(n []int) int {
 		sum := 0
 		for _, num := range n {
 			sum += num
 		}
 		return sum
 	}, "sum", "- sum \"Returns\" the sum of a slice of integers")
+	if err != nil {
+		panic(err)
+	}
 
 	// Print the sum of a slice of numbers
 	script := `{{println (sum .)}}`
-	if err := OutputToTemplate(os.Stdout, "sums", script, nums, cfg); err != nil {
+	if err = OutputToTemplate(os.Stdout, "sums", script, nums, cfg); err != nil {
 		panic(err)
 	}
 	// output:

--- a/tfortools_test.go
+++ b/tfortools_test.go
@@ -154,9 +154,13 @@ func TestOptAllFns(t *testing.T) {
 	oldMapLen := len(funcMap)
 	oldSliceLen := len(funcHelpSlice)
 	cfg := NewConfig(OptAllFns)
-	cfg.AddCustomFn(func() int {
+	err := cfg.AddCustomFn(func() int {
 		return 0
 	}, "zero", "- zero \"Returns\" zero")
+	if err != nil {
+		t.Errorf("AddCustomFn failed with err : %v", err)
+	}
+
 	if oldMapLen != len(funcMap) {
 		t.Errorf("Global funcmap should not be modified")
 	}


### PR DESCRIPTION
This PR enables travis builds for tfortools.  As part of our travis build we run gometalinter, which in turn runs errcheck.  Errcheck had identified two small errors which are fixed by this PR.