### PR TITLE
Add support for documentation tags

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -48,8 +48,8 @@ func ExampleGenerateUsageDecorated() {
 
 func ExampleGenerateUsageUndecorated() {
 	i := struct {
-		X       int
-		Y       string
+		X       int    `tfortools:"This is an int"`
+		Y       string `json:"omitempty" tfortools:"This is a string"`
 		hidden  float64
 		Invalid chan int
 	}{}
@@ -57,8 +57,8 @@ func ExampleGenerateUsageUndecorated() {
 	fmt.Println(help)
 	// output:
 	// struct {
-	// 	X int
-	// 	Y string
+	// 	X int    // This is an int
+	// 	Y string `json:"omitempty"` // This is a string
 	// }
 }
 

--- a/examples/tmplex/tmplex.go
+++ b/examples/tmplex/tmplex.go
@@ -27,13 +27,13 @@ import (
 )
 
 type stock struct {
-	Ticker    string
-	Name      string
-	LastTrade time.Time
-	Current   float64
-	High      float64
-	Low       float64
-	Volume    int
+	Ticker    string    `tfortools:"Ticker Symbol"`
+	Name      string    `tfortools:"Stock name"`
+	LastTrade time.Time `tfortools:"Time at which the stock was last traded"`
+	Current   float64   `tfortools:"The current value of the stock"`
+	High      float64   `tfortools:"The highest value the stock has reached today"`
+	Low       float64   `tfortools:"The lowest value the stock has reached today"`
+	Volume    int       `tfortools:"The number of shares traded today"`
 }
 
 // Cols that creates a new type that execludes certain fields from a struct

--- a/tfortools.go
+++ b/tfortools.go
@@ -761,9 +761,14 @@ func CreateTemplate(name, tmplSrc string, cfg *Config) (*template.Template, erro
 }
 
 // GenerateUsageUndecorated returns a formatted string identifying the
-// elements of the type of object i that can be accessed  from inside a template.
+// elements of the type of object i that can be accessed from inside a template.
 // Unexported struct values and channels are not output as they cannot be usefully
 // accessed inside a template.
+//
+// The output produced by GenerateUsageUndecorated preserves structure tags.
+// There is one special case however.  Tags with a key of "tfortools" are
+// output as comments at the end of the line containing the field, rather
+// than as tags.  This tag can be used to document your structures.
 func GenerateUsageUndecorated(i interface{}) string {
 	var buf bytes.Buffer
 	generateIndentedUsage(&buf, i)

--- a/tfortools_test.go
+++ b/tfortools_test.go
@@ -56,13 +56,13 @@ var templateUsageTests = []struct {
 	{struct{ Empty struct{} }{}, "struct { Empty struct{\n}}"},
 	{struct{}{}, "struct {\n}"},
 	{struct {
-		X int            `test:"tag"`
+		X int            `test:"tag" tfortools:"It's " tfortools:"an \"int\""`
 		Y []int          `test:"tag"`
 		Z map[string]int `test:"tag"`
 		B struct {
-			A int
+			A int `tfortools:"Another int"`
 		} `test:"tag"`
-	}{}, "struct { X int `test:\"tag\"`; Y []int `test:\"tag\"`; Z map[string]int `test:\"tag\"`; B struct {\nA int\n} `test:\"tag\"`} "},
+	}{}, "struct { X int `test:\"tag\"` // It's an \"int\"\n Y []int `test:\"tag\"`; Z map[string]int `test:\"tag\"`; B struct {\nA int // Another int\n} `test:\"tag\"`} "},
 	{[]struct {
 		X int
 		Y string


### PR DESCRIPTION
The code in tfortools that describes the types of variables now
searches for a structure tag called tfortools.  If the tag is found
the value of the tag are output as comments at the end of the
line on which the field appears.  The tfortools tag does not appear
as a tag.

For example

  type stock struct {
 	Ticker    string    `tfortools:"Ticker Symbol"`
  }

is output as

  struct {
	Ticker    string    // Ticker Symbol
  }

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>