### PR TITLE
Add badges to the README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# Template for Tools
+
+[![Go Report Card](https://goreportcard.com/badge/github.com/intel/tfortools)](https://goreportcard.com/report/github.com/intel/tfortools)
+[![Build Status](https://travis-ci.org/intel/tfortools.svg?branch=master)](https://travis-ci.org/intel/tfortools)
+[![GoDoc](https://godoc.org/github.com/intel/tfortools?status.svg)](https://godoc.org/github.com/intel/tfortools)
+
 Package tfortools provides a set of functions that are designed to
 make it easier for developers to add template based scripting to their
 command line tools.


### PR DESCRIPTION
This commit adds the following badges to the README.md file
- Travis build status on master
- Go report card
- Godoc

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>