### PR TITLE
Fix project name in the README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Template for Tools
+# Templates for Tools
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/intel/tfortools)](https://goreportcard.com/report/github.com/intel/tfortools)
 [![Build Status](https://travis-ci.org/intel/tfortools.svg?branch=master)](https://travis-ci.org/intel/tfortools)


### PR DESCRIPTION
Rather embaressingly the name of the project was incorrect in the README.md
file.  It was given as Template for Tools instead of Templates for Tools.

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>