### PR TITLE
Fail CI builds if coverage decreases by 1%

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,9 @@ matrix:
 before_install:
   - go get github.com/alecthomas/gometalinter
   - gometalinter --install
+  - go get github.com/mattn/goveralls
 
 script:
    - go env
-   - go test -v ./...
+   - $GOPATH/bin/goveralls -v -service=travis-ci --package github.com/intel/tfortools
    - gometalinter --tests --vendor --disable-all --enable=misspell --enable=vet --enable=ineffassign --enable=gofmt --enable=gocyclo --cyclo-over=15 --enable=golint --enable=errcheck --enable=deadcode ./...

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/intel/tfortools)](https://goreportcard.com/report/github.com/intel/tfortools)
 [![Build Status](https://travis-ci.org/intel/tfortools.svg?branch=master)](https://travis-ci.org/intel/tfortools)
 [![GoDoc](https://godoc.org/github.com/intel/tfortools?status.svg)](https://godoc.org/github.com/intel/tfortools)
+[![Coverage Status](https://coveralls.io/repos/github/intel/tfortools/badge.svg?branch=master)](https://coveralls.io/github/intel/tfortools?branch=master)
 
 Package tfortools provides a set of functions that are designed to
 make it easier for developers to add template based scripting to their


### PR DESCRIPTION
This commit enables unit test coverage computation in Travis CI builds.
Going forward, builds that decrease the unit test coverage by more than
1.0% will fail.

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>